### PR TITLE
[collection] Add method to help get a list with column values

### DIFF
--- a/src/AbstractListCollection.php
+++ b/src/AbstractListCollection.php
@@ -201,6 +201,11 @@ abstract class AbstractListCollection implements ListCollection
 		return $newCollection;
 	}
 
+	public function column(callable $callback): array
+	{
+		return $this->data->map($callback)->toArray();
+	}
+
 	public function merge(Collection ...$collections): static
 	{
 		$newCollection = $this->data;

--- a/src/AbstractMapCollection.php
+++ b/src/AbstractMapCollection.php
@@ -214,6 +214,15 @@ abstract class AbstractMapCollection implements MapCollection
 		return $newCollection;
 	}
 
+	public function column(callable $callback): array
+	{
+		$column = [];
+		foreach ($this->data as $row) {
+			$column[] = $callback($row);
+		}
+		return $column;
+	}
+
 	public function merge(Collection ...$collections): static
 	{
 		$newCollection = $this->data;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -51,4 +51,11 @@ interface Collection extends \Countable, \IteratorAggregate
 	 * @return Collection<T>
 	 */
 	public function indexBy(callable $callback): Collection;
+
+	/**
+	 * @template R
+	 * @param callable(T): R $callback
+	 * @return list<R>
+	 */
+	public function column(callable $callback): array;
 }

--- a/tests/GenericListCollectionTest.php
+++ b/tests/GenericListCollectionTest.php
@@ -260,4 +260,21 @@ final class GenericListCollectionTest extends TestCase
 			$this->assertSame($expectedValues[$index], $value->value);
 		}
 	}
+
+	public function testColumn(): void
+	{
+		$collection1 = new GenericListCollection(RandomEntity::class, [
+			new RandomEntity(1),
+			new RandomEntity(2),
+			new RandomEntity(3),
+			new RandomEntity(4),
+			new RandomEntity(5),
+		]);
+
+		$values = $collection1->column(fn (RandomEntity $r) => $r->value);
+
+		$this->assertCount(5, $values);
+		$this->assertIsList($values);
+		$this->assertSame([1, 2, 3, 4, 5], $values);
+	}
 }

--- a/tests/GenericMapCollectionTest.php
+++ b/tests/GenericMapCollectionTest.php
@@ -310,4 +310,21 @@ final class GenericMapCollectionTest extends TestCase
 
 		$this->assertSame(ExtraEntity::class, $collection->getType());
 	}
+
+	public function testColumn(): void
+	{
+		$collection1 = new GenericMapCollection(RandomEntity::class, [
+			'key1' => new RandomEntity('1'),
+			'key2' => new RandomEntity('2'),
+			'key3' => new RandomEntity('3'),
+			'key4' => new RandomEntity('4'),
+			'key5' => new RandomEntity('5'),
+		]);
+
+		$values = $collection1->column(fn (RandomEntity $r) => $r->value);
+
+		$this->assertCount(5, $values);
+		$this->assertIsList($values);
+		$this->assertSame(['1', '2', '3', '4', '5'], $values);
+	}
 }


### PR DESCRIPTION
This can be help full if you have an Collection with database objects and want to get all the ids.

This code is phpstan type complete

	$ids => $collection->column(fn (A $a) => $a->id); // id is a Uuid

	\PhpStan\dumpType($ids); // list<Uuid>